### PR TITLE
[clang-apply-replacements] Fix missing dependency - clangToolingRefactoring

### DIFF
--- a/clang-apply-replacements/CMakeLists.txt
+++ b/clang-apply-replacements/CMakeLists.txt
@@ -11,6 +11,7 @@ add_clang_library(clangApplyReplacements
   clangRewrite
   clangToolingCore
   clangToolingRefactor
+  clangToolingRefactoring
   )
 
 include_directories(


### PR DESCRIPTION
Fixes linker error:
  Undefined symbols for architecture x86_64:
    "clang::tooling::AtomicChange::replace(clang::SourceManager const&, clang::SourceLocation, unsigned int, llvm::StringRef)"