### PR TITLE
Cleanup: llvm::bsearch -> llvm::partition_point after r364719

### DIFF
--- a/clangd/index/Symbol.cpp
+++ b/clangd/index/Symbol.cpp
@@ -35,8 +35,8 @@ float quality(const Symbol &S) {
 }
 
 SymbolSlab::const_iterator SymbolSlab::find(const SymbolID &ID) const {
-  auto It =
-      llvm::bsearch(Symbols, [&](const Symbol &S) { return !(S.ID < ID); });
+  auto It = llvm::partition_point(Symbols,
+                                  [&](const Symbol &S) { return S.ID < ID; });
   if (It != Symbols.end() && It->ID == ID)
     return It;
   return Symbols.end();

--- a/clangd/index/dex/PostingList.cpp
+++ b/clangd/index/dex/PostingList.cpp
@@ -50,8 +50,8 @@ public:
       return;
     advanceToChunk(ID);
     // Try to find ID within current chunk.
-    CurrentID = llvm::bsearch(CurrentID, DecompressedChunk.end(),
-                              [&](const DocID D) { return D >= ID; });
+    CurrentID = std::partition_point(CurrentID, DecompressedChunk.end(),
+                                     [&](const DocID D) { return D < ID; });
     normalizeCursor();
   }
 
@@ -103,8 +103,8 @@ private:
     if ((CurrentChunk != Chunks.end() - 1) &&
         ((CurrentChunk + 1)->Head <= ID)) {
       CurrentChunk =
-          llvm::bsearch(CurrentChunk + 1, Chunks.end(),
-                        [&](const Chunk &C) { return C.Head >= ID; });
+          std::partition_point(CurrentChunk + 1, Chunks.end(),
+                               [&](const Chunk &C) { return C.Head < ID; });
       --CurrentChunk;
       DecompressedChunk = CurrentChunk->decompress();
       CurrentID = DecompressedChunk.begin();


### PR DESCRIPTION
git-svn-id: https://llvm.org/svn/llvm-project/clang-tools-extra/trunk@364720 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 8dd14b2f4488030949ff1eaf5ad651bd1954e1dc)